### PR TITLE
include the "tutorial" directory in clojure build source paths

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
                  [navis/untangled-datomic "0.4.4"]]
 
   ; server source paths
-  :source-paths ["src/server" "src/shared" "test/server" "test/shared"]
+  :source-paths ["src/server" "src/shared" "src/tutorial" "test/server" "test/shared"]
   :test-paths ["test/server" "test/shared"]
 
   :plugins [[lein-cljsbuild "1.1.2"]


### PR DESCRIPTION
We need to include the `tutorial` directory in clojure source paths to prevent this error happening:

```
JVM_OPTS="-server -Dtutorial" rlwrap lein run -m clojure.main ./script/figwheel.clj
STARTING FIGWHEEL ON BUILDS:  (tutorial)
Figwheel: Starting server at http://localhost:3449
Figwheel: Watching build - tutorial
Compiling "resources/public/js/tutorial.js" from ["src/tutorial" "src/shared"]...
{:tag :cljs/analysis-error}
ANALYSIS ERROR: Could not locate untangled_tutorial/tutmacros__init.class or untangled_tutorial/tutmacros.clj on classpath. Please check that namespaces with dashes use underscores in the Clojure file name. in file src/tutorial/cljs/untangled_tutorial/G_Mutation_Exercises.cljs on file null, line null, column null
```
